### PR TITLE
[TEST] show course videos count test added

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Course extends Model
 {
@@ -17,5 +18,10 @@ class Course extends Model
     public function scopeReleased(Builder $query): Builder
     {
         return $query->whereNotNull('released_at');
+    }
+
+    public function videos(): HasMany
+    {
+        return $this->hasMany(Video::class);
     }
 }

--- a/app/Models/Video.php
+++ b/app/Models/Video.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Video extends Model
+{
+    use HasFactory;
+}

--- a/database/factories/CourseFactory.php
+++ b/database/factories/CourseFactory.php
@@ -19,8 +19,15 @@ class CourseFactory extends Factory
     {
         return [
             'slug' => $this->faker->slug,
+            'tagline' => $this->faker->sentence,
             'title' => $this->faker->sentence,
             'description' => $this->faker->paragraph,
+            'image' => 'image.png',
+            'learnings' => [
+                'Learn A',
+                'Learn B',
+                'Learn C',
+            ],
         ];
     }
 

--- a/database/factories/VideoFactory.php
+++ b/database/factories/VideoFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Video>
+ */
+class VideoFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+   
+        ];
+    }
+}

--- a/database/migrations/2024_06_11_090204_create_videos_table.php
+++ b/database/migrations/2024_06_11_090204_create_videos_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('videos', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('course_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('videos');
+    }
+};

--- a/resources/views/course-details.blade.php
+++ b/resources/views/course-details.blade.php
@@ -9,6 +9,10 @@
 <p>
     {{$course->description}}
 </p>
+<p>
+    {{count($course->videos)}}videos
+</p>
+
 
 <ul>
     @foreach ($course->learnings as $learning)

--- a/tests/Feature/CourseTest.php
+++ b/tests/Feature/CourseTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Course;
+use App\Models\Video;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
@@ -16,4 +17,17 @@ it('only returns released courses for released scope', function () {
         ->first()
         ->id
         ->toEqual(1);
+});
+
+it('has videos', function () {
+    // Arrange
+    $course = Course::factory()->create();
+    Video::factory()->count(3)->create([
+        'course_id' => $course->id
+    ]);
+
+    // act and assert
+    expect($course->videos)
+        ->toHaveCount(3)
+        ->each->toBeInstanceOf(Video::class);
 });

--- a/tests/Feature/PageCourseDetailsTest.php
+++ b/tests/Feature/PageCourseDetailsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Course;
+use App\Models\Video;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use function Pest\Laravel\get;
@@ -32,6 +33,14 @@ it('shows course details', function () {
         ->assertSee('image.png');
 });
 
-it('it shows course vide count', function () {
-
+it('shows course video count', function () {
+    // Arrange
+    $course = Course::factory()->create();
+    Video::factory()->count(3)->create([
+        'course_id' => $course->id
+    ]);
+    // Act & Assert
+    get(route('course-details', $course))
+        ->assertOk()
+        ->assertSeeText('3videos');
 });


### PR DESCRIPTION
In this lesson, we create a new course and add videos to it. We then make a GET request to the course details route and ensure that the correct number of videos is displayed on the page. We also encounter some errors related to missing taglines, images, and a default learning field, which we address using factories and migrations. Finally, we define a relationship between the course and video models and write tests to verify the relationship.